### PR TITLE
Extend tag check feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,4 +596,38 @@ public class CoffeeMachineTagCheckTest {
 }
 ```
 
+### Check extension
+Default check ensures all tags exist in the dictionary. If you want to
+assess that you cover a full perimeter you can use a distinct TagChecker
+
+```java
+
+    @SanityTagChecker.TagDictionaryProvider
+    public static TagDictionary tagDictionary() {
+        return new TagDictionary()
+                .declareTag("@coffee")
+                .declareTag("@tea")
+                .declareTag("@chocolate")
+                .declareTag("@orangeJuice")
+                .declareTag("@noDrink")
+                ;
+    }
+
+    @SanityTagChecker.FeaturesProvider
+    public static Features features() {
+        String basedir = new TestSettings().getBaseDir();
+        return loadFeaturesFromSourceDirectory(new File(basedir, "src/main/resources/samples/coffeemachine"));
+    }
+    
+    @SanityTagChecker.TagCheckerProvider
+    public static TagChecker checker() {
+        return new CheckAtLeastOneTagsExist();
+    }
+
+    @SanityTagChecker.CheckScopeProvider
+    public static Set<CucumberPart> scope() {
+        return EnumSet.of(CucumberPart.Scenario);
+    }
+```
+
 

--- a/tzatziki-core/src/main/java/tzatziki/analysis/check/CheckAllTagsExist.java
+++ b/tzatziki-core/src/main/java/tzatziki/analysis/check/CheckAllTagsExist.java
@@ -1,0 +1,29 @@
+package tzatziki.analysis.check;
+
+import java.util.List;
+
+import org.junit.Assert;
+
+import com.google.common.collect.Lists;
+
+import tzatziki.analysis.tag.TagDictionary;
+
+/**
+ * Check that all tags are declared in the TagDictionary
+ * @author pverdage
+ *
+ */
+public class CheckAllTagsExist implements TagChecker {
+
+    @Override
+    public void evaluate(TagDictionary dictionary, List<String> tags) {
+        List<String> unknown = Lists.newArrayList();
+        for (String tag : tags) {
+            if (!dictionary.containsTag(tag))
+                unknown.add(tag);
+        }
+        if (!unknown.isEmpty())
+            Assert.fail("Unknown tag(s): " + unknown);
+    }
+
+}

--- a/tzatziki-core/src/main/java/tzatziki/analysis/check/CheckAtLeastOneTagsExist.java
+++ b/tzatziki-core/src/main/java/tzatziki/analysis/check/CheckAtLeastOneTagsExist.java
@@ -1,0 +1,27 @@
+package tzatziki.analysis.check;
+
+import java.util.List;
+
+import org.junit.Assert;
+
+import tzatziki.analysis.tag.TagDictionary;
+
+/**
+ * Check that at least on declared tag exist in the TagDictionary.
+ * It can be used to check that there is no orphan test regarding a categorization.
+ * 
+ * @author pverdage
+ *
+ */
+public class CheckAtLeastOneTagsExist implements TagChecker {
+
+    @Override
+    public void evaluate(TagDictionary dictionary, List<String> tags) {
+        for (String tag : tags) {
+            if (dictionary.containsTag(tag))
+                return;
+        }
+        Assert.fail("No tag(s) in dictionary amongst: " + tags);
+    }
+
+}

--- a/tzatziki-core/src/main/java/tzatziki/analysis/check/CucumberPart.java
+++ b/tzatziki-core/src/main/java/tzatziki/analysis/check/CucumberPart.java
@@ -1,0 +1,15 @@
+package tzatziki.analysis.check;
+
+/**
+ * Cucumber part to check
+ * @author pverdage
+ *
+ */
+public enum CucumberPart {
+    Feature,
+    Scenario,
+    ScenarioOutline;
+    
+}
+
+

--- a/tzatziki-core/src/main/java/tzatziki/analysis/check/TagChecker.java
+++ b/tzatziki-core/src/main/java/tzatziki/analysis/check/TagChecker.java
@@ -1,0 +1,9 @@
+package tzatziki.analysis.check;
+
+import java.util.List;
+
+import tzatziki.analysis.tag.TagDictionary;
+
+public interface TagChecker {
+    void evaluate(TagDictionary dictionary, List<String> tags);
+}

--- a/tzatziki-core/src/test/java/tzatziki/junit/SanityTagCheckerTest.java
+++ b/tzatziki-core/src/test/java/tzatziki/junit/SanityTagCheckerTest.java
@@ -1,16 +1,23 @@
 package tzatziki.junit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.EnumSet;
+import java.util.Set;
+
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+
 import tzatziki.TestSettings;
+import tzatziki.analysis.check.CheckAtLeastOneTagsExist;
+import tzatziki.analysis.check.CucumberPart;
+import tzatziki.analysis.check.TagChecker;
 import tzatziki.analysis.step.Features;
 import tzatziki.analysis.tag.TagDictionary;
-
-import java.io.File;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SanityTagCheckerTest {
 
@@ -171,6 +178,44 @@ public class SanityTagCheckerTest {
     private static Features coffeeMachineFeatures() {
         String basedir = new TestSettings().getBaseDir();
         return SanityTagChecker.loadFeaturesFromSourceDirectory(new File(basedir, "src/test/resources/tzatziki/junit/coffeemachine"));
+    }
+
+    @RunWith(SanityTagChecker.class)
+    public static class MissingTypologyTags {
+        @SanityTagChecker.TagDictionaryProvider
+        public static TagDictionary tagDictionary() {
+            return new TagDictionary()
+	            .declareTag("@coffee")
+	            .declareTag("@tea")
+	            .declareTag("@chocolate")
+	            .declareTag("@orangeJuice");
+        }
+
+        @SanityTagChecker.FeaturesProvider
+        public static Features features() {
+            return coffeeMachineFeatures();
+        }
+
+        @SanityTagChecker.TagCheckerProvider
+        public static TagChecker checker() {
+            return new CheckAtLeastOneTagsExist();
+        }
+
+        @SanityTagChecker.CheckScopeProvider
+        public static Set<CucumberPart> scope() {
+            return EnumSet.of(CucumberPart.Scenario);
+        }
+    }
+
+    @Test
+    public void should_fail_when_not_using_typology_tag() {
+        JUnitCore unitCore = new JUnitCore();
+        Result result = unitCore.run(MissingTypologyTags.class);
+        assertThat(result.getFailures()).isNotEmpty();
+        assertThat(result.wasSuccessful()).isFalse();
+        for (Failure failure : result.getFailures()) {
+			assertThat(failure.getMessage()).contains("@noDrink");
+		}
     }
 
 

--- a/tzatziki-core/src/test/java/tzatziki/junit/SanityTagCheckerTest.java
+++ b/tzatziki-core/src/test/java/tzatziki/junit/SanityTagCheckerTest.java
@@ -158,6 +158,7 @@ public class SanityTagCheckerTest {
                     .declareTag("@tea")
                     .declareTag("@chocolate")
                     .declareTag("@orangeJuice")
+                    .declareTag("@noDrink")
                     .declareTag("@sugar")
                     .declareTag("@noSugar")
                     .declareTag("@extraHot")

--- a/tzatziki-core/src/test/resources/tzatziki/junit/coffeemachine/04-making-money.feature
+++ b/tzatziki-core/src/test/resources/tzatziki/junit/coffeemachine/04-making-money.feature
@@ -43,7 +43,7 @@ Feature: Making Money
     Total: 3.00€
     """
 
-  @reporting
+  @reporting @noDrink
   Scenario: Statistics collect no usage
 
     # [asciidiag]

--- a/tzatziki-core/src/test/resources/tzatziki/junit/coffeemachine/05-running-out.feature
+++ b/tzatziki-core/src/test/resources/tzatziki/junit/coffeemachine/05-running-out.feature
@@ -33,7 +33,7 @@ Feature: Running Out
     | Chocolate    |
 
   @manual
-  @notification
+  @notification @noDrink
   Scenario: Manually send an email
     Given an empty machine
     When I click on the "Send Test Email" button

--- a/tzatziki-samples/src/main/resources/samples/coffeemachine/04-making-money.feature
+++ b/tzatziki-samples/src/main/resources/samples/coffeemachine/04-making-money.feature
@@ -39,7 +39,7 @@ Feature: Making Money
     Total: 3.00€
     """
 
-  @reporting
+  @reporting @noDrink
   Scenario: Statistics collect no usage
 
     #```ditaa

--- a/tzatziki-samples/src/main/resources/samples/coffeemachine/05-running-out.feature
+++ b/tzatziki-samples/src/main/resources/samples/coffeemachine/05-running-out.feature
@@ -33,7 +33,7 @@ Feature: Running Out
     | Chocolate    |
 
   @manual
-  @notification
+  @notification @noDrink
   Scenario: Manually send an email
     Given an empty machine
     When I click on the "Send Test Email" button

--- a/tzatziki-samples/src/main/resources/samples/coffeemachine/06-background.feature
+++ b/tzatziki-samples/src/main/resources/samples/coffeemachine/06-background.feature
@@ -31,7 +31,7 @@ Feature: Making Even more Money
     # Represents the default daily activity
     # Basic statistics usage
 
-  @reporting
+  @reporting @noDrink
   Scenario: Statistics collect basic usage
 
     # **Report is queried** and generated on-the-fly.
@@ -46,7 +46,7 @@ Feature: Making Even more Money
     Total: 3.00€
     """
 
-  @reporting
+  @reporting @noDrink
   Scenario: Statistics collect basic usage
 
     When I order a "Coffee" with 5 sugar

--- a/tzatziki-samples/src/test/java/samples/coffeemachine/CoffeeMachineDrinkTagCheckTest.java
+++ b/tzatziki-samples/src/test/java/samples/coffeemachine/CoffeeMachineDrinkTagCheckTest.java
@@ -1,0 +1,51 @@
+package samples.coffeemachine;
+
+import static tzatziki.junit.SanityTagChecker.loadFeaturesFromSourceDirectory;
+
+import java.io.File;
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.junit.runner.RunWith;
+
+import samples.TestSettings;
+import tzatziki.analysis.check.CheckAtLeastOneTagsExist;
+import tzatziki.analysis.check.CucumberPart;
+import tzatziki.analysis.check.TagChecker;
+import tzatziki.analysis.step.Features;
+import tzatziki.analysis.tag.TagDictionary;
+import tzatziki.junit.SanityTagChecker;
+
+/**
+ * @author <a href="http://twitter.com/aloyer">@aloyer</a>
+ */
+@RunWith(SanityTagChecker.class)
+public class CoffeeMachineDrinkTagCheckTest {
+
+    @SanityTagChecker.TagDictionaryProvider
+    public static TagDictionary tagDictionary() {
+        return new TagDictionary()
+                .declareTag("@coffee")
+                .declareTag("@tea")
+                .declareTag("@chocolate")
+                .declareTag("@orangeJuice")
+                .declareTag("@noDrink")
+                ;
+    }
+
+    @SanityTagChecker.FeaturesProvider
+    public static Features features() {
+        String basedir = new TestSettings().getBaseDir();
+        return loadFeaturesFromSourceDirectory(new File(basedir, "src/main/resources/samples/coffeemachine"));
+    }
+    
+    @SanityTagChecker.TagCheckerProvider
+    public static TagChecker checker() {
+        return new CheckAtLeastOneTagsExist();
+    }
+
+    @SanityTagChecker.CheckScopeProvider
+    public static Set<CucumberPart> scope() {
+        return EnumSet.of(CucumberPart.Scenario);
+    }
+}


### PR DESCRIPTION
- Provide ability to give a custom TagChecker implementation.
- Keep existing implementation as default (all tags must exist)
- Add new check: at least one of the tags must be in scenario
- Provide ability to test only some parts of the feature: Scenario, ScenarioOutline, Feature. Keep default to all parts

Samples are in README.

Added a test fix found while release private version of the library.